### PR TITLE
fix(validated-field): Should render null when there is no message

### DIFF
--- a/components/Form/FieldMessage.js
+++ b/components/Form/FieldMessage.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Icon, Form } from 'semantic-ui-react'
+import { Form } from 'semantic-ui-react'
 
 export class FormFieldMessage extends Component {
   static propTypes = {
@@ -15,6 +15,11 @@ export class FormFieldMessage extends Component {
   render() {
     const { className, message, ...otherProps } = this.props
     const classes = cx('inloco-form-validator__message', className)
+
+    if (!message) {
+      return null
+    }
+
     return (
       <div className={classes} {...otherProps}>
         {message}

--- a/src/site/collections/form.overrides
+++ b/src/site/collections/form.overrides
@@ -56,6 +56,6 @@
   color: @red;
   display: flex;
   font-size: 12px;
-  height: 24px;
   line-height: 1em;
+  margin-top: 4px;
 }


### PR DESCRIPTION
No último PR que abri, gerei um bug.

Quando nenhuma mensagem é passada pra este componente, a gente não precisa renderizar nada, pra ele não gerar node no DOM desnecessariamente, e pra não ocupar espaço na tela.

Acho que agora está ok.

![2019-05-24 11 05 42](https://user-images.githubusercontent.com/1139664/58333509-f61bb480-7e13-11e9-9474-2f5deadea013.gif)
